### PR TITLE
feat: openspec/specs に仕様書を作成

### DIFF
--- a/openspec/changes/archive/2026-01-08-add-initial-specs/proposal.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/proposal.md
@@ -1,0 +1,22 @@
+# Change: Arc-like Chrome拡張機能の初期仕様定義
+
+## Why
+Arc ブラウザの「Spaces / Folders / Pins / Today Tabs」体験を Chrome 拡張機能（Manifest V3）で再現するプロジェクトの MVP 仕様を、OpenSpec 形式で機能ごとに整理・定義する。
+
+## What Changes
+- 10の機能別仕様（capability specs）を追加:
+  - `design-decisions`: **横断的設計判断（他の spec より先に読む前提仕様）**
+  - `space-management`: Space の CRUD と切り替え
+  - `folder-management`: Folder 階層構造の管理
+  - `item-management`: Saved Items（論理タブ）の管理
+  - `pins`: Space ごとのお気に入りアイコン列
+  - `today-tabs`: 未整理の作業中 URL 一覧
+  - `search`: 全体検索機能
+  - `tab-opening`: URL を新規タブで開く動作
+  - `storage`: chrome.storage.local によるデータ永続化
+  - `side-panel-ui`: Side Panel の UI 構成
+
+## Impact
+- Affected specs: 新規作成（既存 spec なし）
+- Affected code: なし（仕様定義のみ）
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/design-decisions/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/design-decisions/spec.md
@@ -1,0 +1,152 @@
+# Design Decisions（横断的設計判断）
+
+> **この spec は他の全ての capability specs を読む前に必ず読む前提仕様である。**
+> 全ての capability specs はこの design-decisions に従うものとする（SHALL）。
+
+## ADDED Requirements
+
+### Requirement: 管理対象の定義
+システムが管理・表示するのは「論理タブ（Saved Items / Today Tabs）」のみとする（SHALL）。Chrome の実タブバーを置き換えてはならない（SHALL NOT）。実タブを自動分類・自動同期してはならない（SHALL NOT）。
+
+#### Scenario: 論理タブのみ管理
+- **GIVEN** ユーザーが Chrome で複数のタブを開いている
+- **WHEN** Side Panel を開く
+- **THEN** 拡張が管理する論理タブ（Saved Items / Today Tabs）のみが表示される
+- **AND** Chrome の実タブ一覧は表示されない
+
+#### Scenario: 実タブの自動分類禁止
+- **GIVEN** ユーザーが Chrome 本体で新しいタブを開く
+- **WHEN** 任意の URL に移動する
+- **THEN** その実タブは自動的に Folder に分類されない
+- **AND** 論理タブとして自動生成されない
+
+### Requirement: Today Tabs への自動追加ルール
+Today Tabs に自動追加するのは「拡張 UI 経由で開いた URL」のみとする（SHALL）。以下の操作から開いた URL は Today Tabs に追加されるものとする：
+- New Tab ボタン
+- Pins のクリック
+- Folder 内 Saved Item のクリック
+- 検索結果のクリック
+
+#### Scenario: 拡張 UI 経由での Today Tabs 追加
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** Pins / Saved Item / 検索結果のいずれかをクリックする
+- **THEN** その URL が Today Tabs の先頭に追加される
+
+#### Scenario: 重複 URL の処理
+- **GIVEN** Today Tabs に URL A が既に存在する
+- **WHEN** 同じ URL A を拡張 UI から開く
+- **THEN** 新しい Item は作成されない
+- **AND** 既存の Item が先頭に移動する
+
+### Requirement: Today Tabs への自動追加の対象外
+以下の操作で開いたタブは Today Tabs に自動追加してはならない（SHALL NOT）：
+- Chrome 本体の「＋」ボタン（新規タブ）
+- Chrome のアドレスバーへの URL 入力
+- 外部アプリケーション（メール、Slack 等）からのリンク
+- ブックマークからの直接オープン
+
+#### Scenario: Chrome 本体からの操作は対象外
+- **GIVEN** ユーザーが Chrome 本体で新規タブを開く
+- **WHEN** アドレスバーに URL を入力して移動する
+- **THEN** Today Tabs には追加されない
+
+#### Scenario: 外部アプリからのリンクは対象外
+- **GIVEN** ユーザーがメールアプリでリンクをクリックする
+- **WHEN** Chrome でそのリンクが開かれる
+- **THEN** Today Tabs には追加されない
+
+### Requirement: Today Tabs の自動削除禁止
+システムは Today Tabs を自動的に削除・アーカイブしてはならない（SHALL NOT）。Today Tabs の削除はユーザーの明示的な操作によってのみ行われるものとする（SHALL）。
+
+#### Scenario: 時間経過による自動削除の禁止
+- **GIVEN** Today Tabs に Item が1週間前から存在する
+- **WHEN** 時間が経過する
+- **THEN** その Item は自動で削除されない
+
+#### Scenario: ユーザー操作による削除のみ許可
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** ユーザーが×ボタンをクリックする
+- **THEN** その Item が削除される
+
+### Requirement: Saved Item のクリック挙動（迷子リセット）
+Folder 内の Saved Item は「起点 URL」として固定されるものとする（SHALL）。Saved Item をクリックすると、常にその起点 URL を新規タブで開くものとする（SHALL）。実タブ内でどれだけページ遷移していても、再クリックで起点に戻れることを保証する。
+
+#### Scenario: 起点 URL への復帰
+- **GIVEN** Saved Item（起点URL: https://docs.example.com）が存在する
+- **AND** ユーザーがそのタブ内で https://docs.example.com/page1/page2 まで遷移している
+- **WHEN** ユーザーが Side Panel で同じ Saved Item をクリックする
+- **THEN** https://docs.example.com が新規タブで開かれる
+
+#### Scenario: 常に新規タブで開く
+- **GIVEN** Saved Item が存在する
+- **WHEN** ユーザーが Saved Item をクリックする
+- **THEN** 既存タブを再利用せず、新規タブで起点 URL が開かれる
+
+### Requirement: favicon フォールバック
+favicon が取得できない場合は、デフォルトの犬アイコン（SVG）を表示するものとする（SHALL）。これは全ての Item 表示箇所（Pins / Today Tabs / Folder Tree / 検索結果）に適用される。
+
+#### Scenario: favicon 取得成功
+- **GIVEN** Item の URL から favicon が取得可能
+- **WHEN** Item が表示される
+- **THEN** 取得した favicon が表示される
+
+#### Scenario: favicon 取得失敗時のフォールバック
+- **GIVEN** Item の URL から favicon が取得できない
+- **WHEN** Item が表示される
+- **THEN** デフォルトの犬アイコンが表示される
+
+### Requirement: URL を開く操作は常に新規タブ
+拡張 UI から URL を開く全ての操作において、常に新規タブで開くものとする（SHALL）。既存タブの URL 置き換えや再利用は行わないものとする（SHALL NOT）。
+
+#### Scenario: 全ての URL オープンは新規タブ
+- **GIVEN** ユーザーが Side Panel で任意の Item をクリックする
+- **WHEN** URL が開かれる
+- **THEN** Chrome の新規タブとして開かれる
+- **AND** 既存のタブは変更されない
+
+### Requirement: Non-Goals（MVP で実装しない機能）
+以下の機能は MVP では実装しないものとする（SHALL NOT）。これらに関連する仕様・UI・ロジックを含めてはならない。
+
+- **Split View**: 画面分割表示
+- **Arc Peek**: プレビューポップアップ
+- **Chrome 実タブの完全同期/置換**: 実タブバーの代替
+- **Today Tabs の自動アーカイブ**: 時間経過による自動整理
+- **実タブから論理タブの自動生成**: 実タブを解析して Item を作成
+
+#### Scenario: Non-Goals の機能は存在しない
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** UI を確認する
+- **THEN** Split View / Peek / 自動アーカイブ設定などの UI は存在しない
+
+### Requirement: データの永続化先
+全てのデータは chrome.storage.local に保存するものとする（SHALL）。ストレージキーは "arcish_state" を使用するものとする（SHALL）。外部サーバーへの同期は行わないものとする（SHALL NOT）。
+
+#### Scenario: ローカルストレージのみ使用
+- **GIVEN** ユーザーがデータを変更する
+- **WHEN** データが保存される
+- **THEN** chrome.storage.local にのみ保存される
+- **AND** 外部サーバーには送信されない
+
+### Requirement: capability specs の優先順位
+この design-decisions spec は他の全ての capability specs に優先するものとする（SHALL）。各 capability spec がこの design-decisions と矛盾する場合、design-decisions の内容が優先される。
+
+#### Scenario: 矛盾時の優先順位
+- **GIVEN** capability spec に design-decisions と異なる記述がある
+- **WHEN** 実装判断を行う
+- **THEN** design-decisions の内容を優先する
+
+---
+
+## Summary: 横断ルール一覧
+
+| カテゴリ | ルール | 根拠 |
+|---------|--------|------|
+| 管理対象 | 論理タブのみ。実タブは管理しない | Chrome との責務分離 |
+| Today Tabs 追加 | 拡張 UI 経由のみ | ユーザーの意図を尊重 |
+| Today Tabs 削除 | 自動削除禁止。手動のみ | データ損失防止 |
+| Saved Item クリック | 常に起点 URL を新規タブで開く | 迷子リセット |
+| URL オープン | 常に新規タブ | 既存作業の保護 |
+| favicon | 取得不可時は犬アイコン | 一貫した UI |
+| データ保存 | chrome.storage.local のみ | プライバシー・オフライン対応 |
+| Non-Goals | Split View / Peek / 自動アーカイブ等 | MVP スコープ |
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/folder-management/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/folder-management/spec.md
@@ -1,0 +1,69 @@
+# Folder Management
+
+## ADDED Requirements
+
+### Requirement: Folder の定義
+Folder は Space 内の階層構造（ディレクトリ）を表す。各 Folder は親 Folder を持つことができ、木構造を形成するものとする（SHALL）。Folder には Item（Saved Items）を含めることができる。
+
+#### Scenario: Folder の識別
+- **GIVEN** システムに Folder が存在する
+- **WHEN** Folder を参照する
+- **THEN** 一意の ID で識別できる
+
+#### Scenario: Folder のプロパティ
+- **GIVEN** Folder が存在する
+- **WHEN** Folder の情報を取得する
+- **THEN** 名前（name）、所属 Space ID、親 Folder ID（ルートの場合は null）を含む
+
+### Requirement: Folder の作成
+ユーザーは Space 内に新しい Folder を作成できるものとする（SHALL）。
+
+#### Scenario: ルートレベル Folder 作成
+- **GIVEN** アクティブな Space が選択されている
+- **WHEN** ユーザーが新しい Folder を作成する
+- **THEN** 親 Folder を持たないルート Folder が作成される
+
+#### Scenario: サブ Folder 作成
+- **GIVEN** 親 Folder が存在する
+- **WHEN** ユーザーがその Folder 内に新しい Folder を作成する
+- **THEN** 親 Folder の子として新しい Folder が作成される
+
+### Requirement: Folder の展開・折りたたみ
+ユーザーは Folder Tree 内の Folder を展開・折りたたみできるものとする（SHALL）。展開状態は UI 状態として永続化される。
+
+#### Scenario: Folder 展開
+- **GIVEN** 折りたたまれた Folder が存在する
+- **WHEN** ユーザーが Folder をクリックして展開する
+- **THEN** 子 Folder と Item が表示される
+- **AND** expandedFolderIds に追加される
+
+#### Scenario: Folder 折りたたみ
+- **GIVEN** 展開された Folder が存在する
+- **WHEN** ユーザーが Folder をクリックして折りたたむ
+- **THEN** 子 Folder と Item が非表示になる
+- **AND** expandedFolderIds から削除される
+
+### Requirement: Folder の削除
+ユーザーは Folder を削除できるものとする（SHALL）。削除時は、その Folder 内の全ての子 Folder と Item も同時に削除される。
+
+#### Scenario: Folder 削除
+- **GIVEN** Folder が存在する
+- **WHEN** ユーザーが Folder を削除する
+- **THEN** その Folder と全ての子孫（Folder/Item）が削除される
+
+### Requirement: Folder の名前変更
+ユーザーは Folder の名前を変更できるものとする（SHALL）。
+
+#### Scenario: Folder 名前変更
+- **GIVEN** Folder が存在する
+- **WHEN** ユーザーが新しい名前を入力して確定する
+- **THEN** Folder の名前が更新される
+
+### Requirement: Folder Tree の構築
+システムは現在の Space 内の Folder を木構造（Folder Tree）として組み立てて表示するものとする（SHALL）。
+
+#### Scenario: Folder Tree 表示
+- **GIVEN** アクティブな Space が選択されている
+- **WHEN** Side Panel が表示される
+- **THEN** その Space に属する Folder が階層構造で表示される
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/item-management/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/item-management/spec.md
@@ -1,0 +1,123 @@
+# Item Management（Saved Items / 論理タブ）
+
+## ADDED Requirements
+
+### Requirement: Item の定義
+Item（Saved Item / 論理タブ）は保存された URL（起点 URL）を表す。Item は Folder に属するか、または Today Tabs として未整理状態で存在するものとする（SHALL）。システムは Chrome の実タブを置き換えず、論理タブのみを管理する（SHALL）。
+
+#### Scenario: Item の識別
+- **GIVEN** システムに Item が存在する
+- **WHEN** Item を参照する
+- **THEN** 一意の ID で識別できる
+
+#### Scenario: Item のプロパティ
+- **GIVEN** Item が存在する
+- **WHEN** Item の情報を取得する
+- **THEN** URL（起点URL）、タイトル、favicon URL、bucket（"today" | "saved"）、所属 Folder ID（saved の場合）を含む
+
+### Requirement: bucket と folderId の関係
+bucket="saved" の Item は必ず folderId を持つものとする（SHALL）。bucket="today" の Item は folderId を持たない（null）ものとする（SHALL）。
+
+#### Scenario: Saved Item の folderId
+- **GIVEN** bucket="saved" の Item が存在する
+- **WHEN** Item のプロパティを確認する
+- **THEN** folderId は null ではなく、有効な Folder ID を持つ
+
+#### Scenario: Today Tab の folderId
+- **GIVEN** bucket="today" の Item が存在する
+- **WHEN** Item のプロパティを確認する
+- **THEN** folderId は null である
+
+### Requirement: Item の作成（Folder に保存）
+ユーザーは URL を Folder 内に Item として保存できるものとする（SHALL）。
+
+#### Scenario: Item 保存
+- **GIVEN** Folder が存在する
+- **WHEN** ユーザーが URL を Folder に保存する
+- **THEN** bucket="saved" の Item が作成され、指定 Folder に追加される
+
+### Requirement: Item の削除
+ユーザーは Item を削除できるものとする（SHALL）。Item を削除した場合、その Item に関連する全ての参照（Pins、Today Tabs 表示）も同時に削除されるものとする（SHALL）。
+
+#### Scenario: Saved Item 削除
+- **GIVEN** Folder 内に Item が存在する
+- **WHEN** ユーザーが Item を削除する
+- **THEN** Item がストレージから削除される
+
+#### Scenario: Item 削除時の Pin 参照削除
+- **GIVEN** Item が Pins に追加されている
+- **WHEN** その Item を削除する
+- **THEN** Item がストレージから削除される
+- **AND** Pins リストからその Item ID が削除される
+
+#### Scenario: Item 削除時の整合性
+- **GIVEN** Item が存在する
+- **WHEN** その Item を削除する
+- **THEN** 全ての関連参照（pins.bySpaceId 内の itemId）が削除される
+- **AND** 孤立した参照は残らない
+
+### Requirement: Item の移動
+ユーザーは Item を別の Folder に移動できるものとする（SHALL）。MVP では Item の移動はコンテキストメニュー等のメニュー操作で行うものとする（SHALL）。ドラッグ＆ドロップによる移動は MVP のスコープ外とする。
+
+#### Scenario: Item 移動（メニュー操作）
+- **GIVEN** Item が Folder A に存在する
+- **WHEN** ユーザーがメニューから「移動」を選択し、Folder B を指定する
+- **THEN** Item の所属 Folder が B に更新される
+
+> **NOTE (MVP Scope)**: ドラッグ＆ドロップによる Item 移動は MVP では実装しない。メニュー操作（右クリック / ケバブメニュー等）による移動のみをサポートする。
+
+### Requirement: Item の名前（タイトル）変更
+ユーザーは Item のタイトルを変更できるものとする（SHALL）。
+
+#### Scenario: Item 名前変更
+- **GIVEN** Item が存在する
+- **WHEN** ユーザーが新しいタイトルを入力して確定する
+- **THEN** Item のタイトルが更新される
+
+### Requirement: Today Tab から Saved Item への変換
+ユーザーは Today Tab の Item を Folder に保存して Saved Item に変換できるものとする（SHALL）。MVP ではメニュー操作で行うものとする（SHALL）。
+
+#### Scenario: Today Tab を Folder に保存（メニュー操作）
+- **GIVEN** Today Tab の Item が存在する
+- **WHEN** ユーザーがメニューから「Folder に保存」を選択し、保存先 Folder を指定する
+- **THEN** Item の bucket が "saved" に変更され、指定 Folder に所属する
+- **AND** folderId が指定 Folder の ID に設定される
+
+> **NOTE (MVP Scope)**: ドラッグ＆ドロップによる Today Tab → Folder 保存は MVP では実装しない。
+
+### Requirement: Saved Item のクリック挙動（迷子リセット）
+Saved Item（Folder 内の Item）をクリックすると、常に起点 URL を新規タブで開くものとする（SHALL）。実タブ内でどれだけ遷移していても、再クリックで起点に戻れる。
+
+#### Scenario: Saved Item クリック
+- **GIVEN** Folder 内に Item（起点URL: https://example.com）が存在する
+- **WHEN** ユーザーが Item をクリックする
+- **THEN** 常に https://example.com が新規タブで開かれる
+
+### Requirement: favicon の表示
+Item の favicon を表示する。favicon が取得できない場合は、デフォルトの犬アイコンを表示するものとする（SHALL）。
+
+#### Scenario: favicon 表示
+- **GIVEN** Item の favicon URL が有効である
+- **WHEN** Item が表示される
+- **THEN** favicon が表示される
+
+#### Scenario: favicon 取得失敗時
+- **GIVEN** Item の favicon URL が無効または取得不可
+- **WHEN** Item が表示される
+- **THEN** デフォルトの犬アイコンが表示される
+
+### Requirement: Today Tabs における URL の一意性
+Today Tabs では同一 URL（文字列完全一致）の Item は1つのみ存在できるものとする（SHALL）。重複する URL を Today Tabs に追加しようとした場合、新規 Item を作成せず、既存 Item を再利用するものとする（SHALL）。
+
+#### Scenario: Today Tabs への重複 URL 追加
+- **GIVEN** Today Tabs に URL "https://example.com" の Item が存在する
+- **WHEN** 同じ URL "https://example.com" を拡張 UI から開く
+- **THEN** 新しい Item は作成されない
+- **AND** 既存の Item が Today Tabs の先頭に移動する
+
+#### Scenario: URL の完全一致判定
+- **GIVEN** Today Tabs に URL "https://example.com/page" の Item が存在する
+- **WHEN** URL "https://example.com/page?param=1" を開く
+- **THEN** 文字列が完全一致しないため、新しい Item が作成される
+
+> **NOTE**: URL の一意性判定は文字列完全一致で行う。正規化（末尾スラッシュ、クエリパラメータ順序等）は行わない。これは design-decisions の「重複 URL の処理」要件に準拠している。

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/pins/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/pins/spec.md
@@ -1,0 +1,55 @@
+# Pins
+
+## ADDED Requirements
+
+### Requirement: Pins の定義
+Pins は Space ごとのお気に入り Item をアイコン列として表示する機能である。各 Space は独立した Pins リストを持つものとする（SHALL）。
+
+#### Scenario: Pins の構造
+- **GIVEN** Space が存在する
+- **WHEN** Pins を参照する
+- **THEN** その Space に紐づく Item ID の配列（順序付き）が取得できる
+
+### Requirement: Pins の表示
+Pins は Side Panel の上部に横並びのアイコン列として表示されるものとする（SHALL）。
+
+#### Scenario: Pins 表示
+- **GIVEN** アクティブな Space に Pins が設定されている
+- **WHEN** Side Panel が表示される
+- **THEN** Pins がアイコン列として表示される（favicon または犬アイコン）
+
+### Requirement: Item を Pins に追加
+ユーザーは Item を現在の Space の Pins に追加できるものとする（SHALL）。
+
+#### Scenario: Pins 追加
+- **GIVEN** Item が存在する
+- **WHEN** ユーザーが Item を Pins に追加する
+- **THEN** その Item が Pins リストの末尾に追加される
+
+### Requirement: Pins から Item を削除
+ユーザーは Pins から Item を削除できるものとする（SHALL）。Item 自体は削除されない。
+
+#### Scenario: Pins 削除
+- **GIVEN** Item が Pins に追加されている
+- **WHEN** ユーザーが Pins から削除する
+- **THEN** Pins リストからその Item が削除される
+- **AND** Item 自体は引き続き存在する
+
+### Requirement: Pins のクリック挙動
+Pins をクリックすると、その Item の起点 URL を新規タブで開き、Today Tabs の先頭に追加するものとする（SHALL）。
+
+#### Scenario: Pins クリック
+- **GIVEN** Pins に Item が存在する
+- **WHEN** ユーザーが Pin アイコンをクリックする
+- **THEN** その Item の URL が新規タブで開かれる
+- **AND** Today Tabs の先頭に追加される
+
+### Requirement: Pins の表示順序
+Pins は追加された順序で表示されるものとする（SHALL）。新しく追加された Pin は末尾に配置される。
+
+#### Scenario: Pins の追加順序
+- **GIVEN** Pins に Item A, B が順に追加されている
+- **WHEN** Item C を Pins に追加する
+- **THEN** Pins は A, B, C の順序で表示される
+
+> **NOTE (MVP Scope)**: Pins の並び替え（ドラッグ＆ドロップによる順序変更）は MVP では実装しない。将来的に順序変更が必要になった場合に検討する。

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/search/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/search/spec.md
@@ -1,0 +1,50 @@
+# Search
+
+## ADDED Requirements
+
+### Requirement: 検索入力の常時表示
+Side Panel の上部に検索入力フィールドを常時表示するものとする（SHALL）。
+
+#### Scenario: 検索入力表示
+- **GIVEN** Side Panel が開いている
+- **WHEN** ユーザーが Side Panel を見る
+- **THEN** 検索入力フィールドが常に表示されている
+
+### Requirement: 検索対象
+検索は現在の Space 内の全 Item（Today Tabs + Saved Items）を対象とするものとする（SHALL）。検索対象は Item のタイトルと URL。
+
+#### Scenario: 検索対象範囲
+- **GIVEN** アクティブな Space に Item が存在する
+- **WHEN** ユーザーが検索クエリを入力する
+- **THEN** Today Tabs と Folder 内の全 Item が検索対象となる
+
+### Requirement: 検索フィルタリング
+ユーザーが検索クエリを入力すると、マッチする Item のみが表示されるものとする（SHALL）。
+
+#### Scenario: 検索実行
+- **GIVEN** 複数の Item が存在する
+- **WHEN** ユーザーが "example" と入力する
+- **THEN** タイトルまたは URL に "example" を含む Item のみ表示される
+
+#### Scenario: 検索クリア
+- **GIVEN** 検索フィルタが適用されている
+- **WHEN** ユーザーが検索入力をクリアする
+- **THEN** 全ての Item が通常通り表示される
+
+### Requirement: 検索結果のクリック挙動
+検索結果の Item をクリックすると、その URL を新規タブで開き、Today Tabs の先頭に追加するものとする（SHALL）。
+
+#### Scenario: 検索結果クリック
+- **GIVEN** 検索結果に Item が表示されている
+- **WHEN** ユーザーが Item をクリックする
+- **THEN** その Item の URL が新規タブで開かれる
+- **AND** Today Tabs の先頭に追加される
+
+### Requirement: インクリメンタル検索
+検索は入力に応じてリアルタイムでフィルタリングを行うものとする（SHALL）。
+
+#### Scenario: インクリメンタル検索
+- **GIVEN** 検索入力フィールドにフォーカスがある
+- **WHEN** ユーザーが文字を入力する
+- **THEN** 入力ごとにフィルタ結果が即座に更新される
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/side-panel-ui/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/side-panel-ui/spec.md
@@ -1,0 +1,82 @@
+# Side Panel UI
+
+## ADDED Requirements
+
+### Requirement: Side Panel の使用
+UI は Chrome の Side Panel 上に React アプリとして構築するものとする（SHALL）。
+
+#### Scenario: Side Panel 表示
+- **GIVEN** 拡張がインストールされている
+- **WHEN** ユーザーが拡張アイコンをクリックする
+- **THEN** Side Panel が開き、React UI が表示される
+
+### Requirement: UI セクション構成
+Side Panel は上から順に以下のセクションを表示するものとする（SHALL）：
+1. Header：Space Switcher / Settings
+2. Search：常時表示の検索入力
+3. Pins：横並びアイコン列（favicon or 犬アイコン）
+4. New Tab：拡張経由の新規タブ作成ボタン
+5. Today Tabs：未整理リスト（削除は×ボタン）
+6. Folder Tree：フォルダ階層＋保存 Item
+
+#### Scenario: セクション順序
+- **GIVEN** Side Panel が開いている
+- **WHEN** UI を確認する
+- **THEN** Header → Search → Pins → New Tab → Today Tabs → Folder Tree の順で表示される
+
+### Requirement: Header セクション
+Header には Space Switcher（ドロップダウンまたはタブ）と Settings アクセスを配置するものとする（SHALL）。
+
+#### Scenario: Header 表示
+- **GIVEN** Side Panel が開いている
+- **WHEN** Header を確認する
+- **THEN** 現在の Space 名と切り替え UI が表示される
+
+### Requirement: Pins セクション
+Pins は favicon（または犬アイコン）の横並びアイコン列として表示するものとする（SHALL）。
+
+#### Scenario: Pins アイコン表示
+- **GIVEN** 現在の Space に Pins が設定されている
+- **WHEN** Pins セクションを確認する
+- **THEN** アイコンが横一列に並んで表示される
+
+### Requirement: New Tab ボタン
+New Tab ボタンは Pins と Today Tabs の間に配置するものとする（SHALL）。
+
+#### Scenario: New Tab ボタン配置
+- **GIVEN** Side Panel が開いている
+- **WHEN** UI を確認する
+- **THEN** Pins の下、Today Tabs の上に New Tab ボタンが表示される
+
+### Requirement: Today Tabs セクション
+Today Tabs は未整理リストとして表示し、各 Item に削除用の×ボタンを表示するものとする（SHALL）。
+
+#### Scenario: Today Tabs リスト表示
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** Today Tabs セクションを確認する
+- **THEN** Item がリスト形式で表示され、各 Item に×ボタンがある
+
+### Requirement: Folder Tree セクション
+Folder Tree はフォルダ階層と保存 Item を木構造で表示するものとする（SHALL）。展開・折りたたみが可能。
+
+#### Scenario: Folder Tree 表示
+- **GIVEN** Folder と Saved Item が存在する
+- **WHEN** Folder Tree セクションを確認する
+- **THEN** フォルダが階層構造で表示され、クリックで展開・折りたたみできる
+
+### Requirement: 犬アイコンのフォールバック
+favicon が取得できない場合は、デフォルトの犬アイコン（SVG）を表示するものとする（SHALL）。
+
+#### Scenario: 犬アイコン表示
+- **GIVEN** Item の favicon が取得できない
+- **WHEN** Item が表示される
+- **THEN** favicon の代わりに犬アイコンが表示される
+
+### Requirement: React によるUI実装
+UI は React を使用して実装するものとする（SHALL）。
+
+#### Scenario: React アプリ
+- **GIVEN** Side Panel が開かれる
+- **WHEN** HTML がロードされる
+- **THEN** React アプリがマウントされて UI がレンダリングされる
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/space-management/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/space-management/spec.md
@@ -1,0 +1,51 @@
+# Space Management
+
+## ADDED Requirements
+
+### Requirement: Space の定義
+Space は作業コンテキスト（Work / Private など）を表す最上位の論理単位である。システムは複数の Space を管理し、各 Space は独立した Folder 構造と Pins を持つものとする（SHALL）。
+
+#### Scenario: Space の識別
+- **GIVEN** システムに Space が存在する
+- **WHEN** Space を参照する
+- **THEN** 一意の ID で識別できる
+
+#### Scenario: Space のプロパティ
+- **GIVEN** Space が存在する
+- **WHEN** Space の情報を取得する
+- **THEN** 名前（name）と作成日時を含む
+
+### Requirement: Space の作成
+ユーザーは新しい Space を作成できるものとする（SHALL）。
+
+#### Scenario: 新規 Space 作成
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** 新しい Space 名を入力して作成を実行する
+- **THEN** 新しい Space が作成され、空の Folder 構造と Pins リストが初期化される
+
+### Requirement: Space の切り替え
+ユーザーは Header の Space Switcher を使用して、アクティブな Space を切り替えられるものとする（SHALL）。
+
+#### Scenario: Space 切り替え
+- **GIVEN** 複数の Space が存在する
+- **WHEN** ユーザーが別の Space を選択する
+- **THEN** UI が選択された Space の内容（Pins / Today Tabs / Folders）を表示する
+- **AND** activeSpaceId が更新される
+
+### Requirement: Space の削除
+ユーザーは Space を削除できるものとする（SHALL）。削除時は、その Space に属する全ての Folder、Item、Pins も同時に削除される。
+
+#### Scenario: Space 削除
+- **GIVEN** 複数の Space が存在する
+- **WHEN** ユーザーが Space を削除する
+- **THEN** その Space と関連する全データが削除される
+- **AND** 別の Space が自動的にアクティブになる
+
+### Requirement: Space の名前変更
+ユーザーは Space の名前を変更できるものとする（SHALL）。
+
+#### Scenario: Space 名前変更
+- **GIVEN** Space が存在する
+- **WHEN** ユーザーが新しい名前を入力して確定する
+- **THEN** Space の名前が更新される
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/storage/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/storage/spec.md
@@ -1,0 +1,99 @@
+# Storage
+
+## ADDED Requirements
+
+### Requirement: chrome.storage.local の使用
+データ永続化には chrome.storage.local を使用するものとする（SHALL）。ストレージキーは "arcish_state"。
+
+#### Scenario: データ保存
+- **GIVEN** ユーザーがデータを変更する
+- **WHEN** 変更が確定される
+- **THEN** chrome.storage.local の "arcish_state" キーにデータが保存される
+
+#### Scenario: データ読み込み
+- **GIVEN** 拡張が起動する
+- **WHEN** Side Panel が初期化される
+- **THEN** chrome.storage.local から "arcish_state" を読み込んで状態を復元する
+
+### Requirement: Storage ラッパー
+chrome.storage.local の薄いラッパーを用意し、set/get の I/F を統一するものとする（SHALL）。
+
+#### Scenario: Storage ラッパー使用
+- **GIVEN** UI コンポーネントがデータを操作する
+- **WHEN** データの読み書きを行う
+- **THEN** 統一された get/set API を通じてアクセスする
+
+### Requirement: Zod によるスキーマバリデーション
+ストレージに保存するデータは Zod でスキーマバリデーションを行うものとする（SHALL）。
+
+#### Scenario: データ保存時のバリデーション
+- **GIVEN** データを保存しようとする
+- **WHEN** データが Zod スキーマに適合しない
+- **THEN** エラーが発生し、不正なデータは保存されない
+
+### Requirement: Normalized データ構造
+データは正規化（Normalized）された構造で保存するものとする（SHALL）。
+
+#### Scenario: Normalized 構造
+- **GIVEN** データを保存する
+- **WHEN** ストレージ構造を確認する
+- **THEN** 以下の構造で保存されている:
+  - version: number（スキーマバージョン）
+  - spaces: { byId: {}, allIds: [] }
+  - folders: { byId: {}, allIds: [] }
+  - items: { byId: {}, allIds: [] }
+  - pins: { bySpaceId: { [spaceId]: itemId[] } }
+  - ui: { activeSpaceId, expandedFolderIds }
+
+### Requirement: スキーマバージョン管理
+ストレージに保存するデータには `version: number` フィールドを含めるものとする（SHALL）。初期値は `1` とする（SHALL）。将来のデータ構造変更時にマイグレーションを可能にするためのフィールドである。
+
+#### Scenario: 初期バージョン
+- **GIVEN** 拡張を初めてインストールする
+- **WHEN** 初期データが作成される
+- **THEN** version フィールドの値は 1 である
+
+#### Scenario: バージョンの永続化
+- **GIVEN** データがストレージに保存されている
+- **WHEN** データを読み込む
+- **THEN** version フィールドが含まれている
+
+> **NOTE**: スキーマ変更が発生した場合、version を参照してマイグレーション処理を行う。MVP では version=1 のみをサポートし、マイグレーションロジックは将来の拡張として実装する。
+
+### Requirement: 更新単位（全体保存）
+MVP ではストレージは state 全体を1つのオブジェクトとして保存・更新するものとする（SHALL）。部分的な差分更新は行わないものとする（SHALL NOT）。
+
+#### Scenario: 全体保存
+- **GIVEN** ユーザーが Item を1つ追加する
+- **WHEN** ストレージを更新する
+- **THEN** state 全体が1つのオブジェクトとして chrome.storage.local に保存される
+
+#### Scenario: 差分更新の禁止
+- **GIVEN** state の一部のみが変更された
+- **WHEN** ストレージを更新する
+- **THEN** 変更された部分だけでなく、state 全体を保存する
+- **AND** 部分的なキー更新（例: spaces のみ更新）は行わない
+
+> **NOTE**: 全体保存はシンプルさを優先した MVP 方針である。パフォーマンス上の問題が発生した場合、将来的に差分更新を検討する。
+
+### Requirement: UI 状態の永続化
+UI 状態（activeSpaceId、expandedFolderIds など）も同じストアに含めて永続化するものとする（SHALL）。
+
+#### Scenario: UI 状態の保存
+- **GIVEN** ユーザーが Folder を展開する
+- **WHEN** Side Panel を閉じて再度開く
+- **THEN** 展開状態が復元される
+
+#### Scenario: アクティブ Space の保存
+- **GIVEN** ユーザーが Space を切り替える
+- **WHEN** ブラウザを再起動する
+- **THEN** 最後にアクティブだった Space が選択される
+
+### Requirement: 初期データ
+ストレージが空の場合、デフォルトの初期データを生成するものとする（SHALL）。
+
+#### Scenario: 初回起動時の初期化
+- **GIVEN** 拡張を初めてインストールする
+- **WHEN** ストレージが空である
+- **THEN** デフォルトの Space（例: "Default"）と空の構造が作成される
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/tab-opening/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/tab-opening/spec.md
@@ -1,0 +1,46 @@
+# Tab Opening
+
+## ADDED Requirements
+
+### Requirement: 常に新規タブで開く
+拡張 UI から URL を開く場合、常に新規タブで開くものとする（SHALL）。既存タブの再利用やタブの置き換えは行わない。
+
+#### Scenario: URL を新規タブで開く
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** Item、Pin、検索結果、New Tab ボタンのいずれかをクリックして URL を開く
+- **THEN** Chrome の新規タブで URL が開かれる
+
+### Requirement: New Tab ボタン
+Side Panel に New Tab ボタンを配置し、クリックすると空の新規タブ（chrome://newtab）を開くものとする（SHALL）。
+
+#### Scenario: New Tab ボタンクリック
+- **GIVEN** Side Panel が開いている
+- **WHEN** ユーザーが New Tab ボタンをクリックする
+- **THEN** chrome://newtab が新規タブで開かれる
+
+### Requirement: Tab 作成時の Today Tabs 追加
+拡張 UI 経由で URL を開いた場合、その URL を Today Tabs の先頭に追加するものとする（SHALL）。
+
+#### Scenario: Tab 作成と Today Tabs 追加
+- **GIVEN** Folder 内に Item（URL: https://example.com）が存在する
+- **WHEN** ユーザーが Item をクリックする
+- **THEN** https://example.com が新規タブで開かれる
+- **AND** Today Tabs の先頭に追加される（bucket="today" の Item として）
+
+### Requirement: 重複 URL の処理
+既に Today Tabs に同じ URL が存在する場合、重複作成せず既存 Item を先頭に移動するものとする（SHALL）。
+
+#### Scenario: 重複 URL を開く
+- **GIVEN** Today Tabs に URL A の Item が存在する
+- **WHEN** ユーザーが同じ URL A を別の場所から開く
+- **THEN** 新規タブは開かれる
+- **AND** 既存の Today Tab Item が先頭に移動する（重複作成しない）
+
+### Requirement: Background Service Worker での Tab 作成
+タブ作成は Background Service Worker（tabs.create API）を通じて行うものとする（SHALL）。
+
+#### Scenario: tabs.create 呼び出し
+- **GIVEN** ユーザーが URL を開く操作を行う
+- **WHEN** Side Panel が chrome.tabs.create を呼び出す
+- **THEN** 新規タブが作成される
+

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/specs/today-tabs/spec.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/specs/today-tabs/spec.md
@@ -1,0 +1,64 @@
+# Today Tabs
+
+## ADDED Requirements
+
+### Requirement: Today Tabs の定義
+Today Tabs は未整理の作業中 URL 一覧である。bucket="today" の Item がここに表示されるものとする（SHALL）。Today Tabs は自動で消さず、ユーザーが明示的に削除するまで保持されるものとする（SHALL）。
+
+#### Scenario: Today Tabs の識別
+- **GIVEN** Item が存在する
+- **WHEN** Item の bucket が "today" である
+- **THEN** その Item は Today Tabs に表示される
+
+### Requirement: Today Tabs の表示
+Today Tabs は Side Panel の Folder Tree の上に、未整理リストとして表示されるものとする（SHALL）。各 Item には×ボタン（削除）が表示される。
+
+#### Scenario: Today Tabs 表示
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** Side Panel が表示される
+- **THEN** Today Tabs セクションに Item リストが表示される
+- **AND** 各 Item に×ボタンが表示される
+
+### Requirement: Today Tabs への自動追加（拡張経由）
+拡張 UI（New Tab ボタン、Pins、Folder 内 Item、検索結果）から URL を開いた場合、Today Tabs の先頭に自動追加するものとする（SHALL）。
+
+#### Scenario: 拡張 UI から URL を開く
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** New Tab ボタン、Pin、Folder Item、検索結果のいずれかをクリックして URL を開く
+- **THEN** その URL が Today Tabs の先頭に追加される（重複時は既存を先頭に移動）
+
+### Requirement: Today Tabs への自動追加の対象外
+Chrome 本体の「＋」新規タブ、アドレスバー入力、外部アプリ起点で開いたタブは Today Tabs に自動追加しないものとする（SHALL NOT）。
+
+#### Scenario: Chrome 本体からタブを開く
+- **GIVEN** ユーザーが Chrome 本体で新規タブを開く
+- **WHEN** アドレスバーに URL を入力して移動する
+- **THEN** Today Tabs には追加されない
+
+### Requirement: Today Tabs の手動削除
+ユーザーは Today Tab の×ボタンをクリックして、その Item を削除できるものとする（SHALL）。
+
+#### Scenario: Today Tab 削除
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** ユーザーが×ボタンをクリックする
+- **THEN** その Item がストレージから削除される
+
+### Requirement: Today Tabs は自動削除しない
+システムは Today Tabs を自動的に削除・アーカイブしないものとする（SHALL NOT）。
+
+#### Scenario: Today Tabs の自動削除禁止
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** 時間が経過する（1日後、1週間後など）
+- **THEN** Item は自動で削除されない
+
+### Requirement: Today Tab から Folder への保存
+ユーザーは Today Tab の Item を Folder に保存して Saved Item に変換できるものとする（SHALL）。MVP では、メニュー操作（コンテキストメニュー / ケバブメニュー等）による明示的な UI 操作で行うものとする（SHALL）。
+
+#### Scenario: Today Tab を Folder に保存（メニュー操作）
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** ユーザーがメニューから「Folder に保存」を選択し、保存先 Folder を指定する
+- **THEN** Item の bucket が "saved" に変更される
+- **AND** folderId が指定 Folder の ID に設定される
+- **AND** Today Tabs から消える（bucket が "today" でなくなるため）
+
+> **NOTE (MVP Scope)**: ドラッグ＆ドロップによる Today Tab → Folder 保存は MVP では実装しない。メニュー操作のみをサポートする。これは item-management spec の方針と整合している。

--- a/openspec/changes/archive/2026-01-08-add-initial-specs/tasks.md
+++ b/openspec/changes/archive/2026-01-08-add-initial-specs/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Arc-like Chrome拡張機能の初期仕様定義
+
+## 1. プロジェクト基盤
+- [ ] 1.1 Manifest V3 + Side Panel の Chrome 拡張プロジェクト構造を作成
+- [ ] 1.2 Vite + React + TypeScript のビルド環境を構築
+- [ ] 1.3 pnpm で依存関係を管理
+
+## 2. Storage Layer
+- [ ] 2.1 chrome.storage.local のラッパーを実装
+- [ ] 2.2 Zod でスキーマバリデーションを実装
+- [ ] 2.3 初期データ構造（Normalized）を定義
+
+## 3. Domain / Entities
+- [ ] 3.1 Space / Folder / Item / Pin の型定義を作成
+- [ ] 3.2 FolderTree 構築 selector を実装
+- [ ] 3.3 Search filter selector を実装
+- [ ] 3.4 Today Tabs 抽出 selector を実装
+- [ ] 3.5 Pins 抽出 selector を実装
+
+## 4. UI 骨格
+- [ ] 4.1 Side Panel のセクション配置を実装
+- [ ] 4.2 Header（Space Switcher）コンポーネントを実装
+- [ ] 4.3 Search 入力コンポーネントを実装
+- [ ] 4.4 Pins アイコン列コンポーネントを実装
+- [ ] 4.5 New Tab ボタンを実装
+- [ ] 4.6 Today Tabs リストを実装
+- [ ] 4.7 Folder Tree コンポーネントを実装
+
+## 5. CRUD 操作
+- [ ] 5.1 Space CRUD を実装
+- [ ] 5.2 Folder CRUD を実装
+- [ ] 5.3 Item CRUD を実装
+- [ ] 5.4 Pin 追加/削除を実装
+- [ ] 5.5 Today Tab 削除を実装
+
+## 6. Tab Opening
+- [ ] 6.1 常に新規タブで URL を開く機能を実装
+- [ ] 6.2 拡張経由で開いた URL を Today Tabs 先頭に追加
+

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,31 +1,61 @@
 # Project Context
 
 ## Purpose
-[Describe your project's purpose and goals]
+Arc ブラウザの「Spaces / Folders / Pins / Today Tabs」体験を、Google Chrome の拡張機能（Manifest V3）で再現する。Arc の Split View / Peek は不要。実用性重視。
 
 ## Tech Stack
-- [List your primary technologies]
-- [e.g., TypeScript, React, Node.js]
+- Platform: Chrome Extension (Manifest V3)
+- UI: Side Panel
+- Language: TypeScript
+- Framework: React
+- Build: Vite
+- Package Manager: pnpm
+- Storage: chrome.storage.local (key: arcish_state)
+- Schema Validation: Zod
 
 ## Project Conventions
 
 ### Code Style
-[Describe your code style preferences, formatting rules, and naming conventions]
+- TypeScript strict mode
+- React functional components with hooks
+- Normalized data structure for state management
 
 ### Architecture Patterns
-[Document your architectural decisions and patterns]
+- Side Panel UI (React)
+- Background Service Worker for tab operations
+- Storage layer with Zod validation
+- Domain selectors for data transformation
 
 ### Testing Strategy
-[Explain your testing approach and requirements]
+[TBD - to be defined during implementation]
 
 ### Git Workflow
-[Describe your branching strategy and commit conventions]
+[TBD - to be defined]
 
 ## Domain Context
-[Add domain-specific knowledge that AI assistants need to understand]
+
+### Core Concepts
+- **Space**: 作業コンテキスト（Work / Private など）
+- **Folder**: Space 内の階層構造（ディレクトリ）
+- **Item (Saved Item / 論理タブ)**: 保存された URL（起点URL）
+- **Pins**: Space ごとのお気に入り（アイコン列）
+- **Today Tabs**: 未整理の作業中URL一覧（自動では消さない）
+
+### Key Design Decisions
+1. 管理対象は「論理タブ（Saved Items）」のみ。Chrome 実タブは置き換えない。
+2. Today Tabs は「拡張経由で開いたもののみ」自動追加。Chrome本体の + やアドレスバー入力は対象外。
+3. Today Tabs は自動で消さない（ユーザーが明示的に削除）。
+4. 保存Item（Folder内Item）は「起点URL」。クリックすると常に起点URLを新規タブで開く（迷子リセット）。
+5. favicon が取れない場合は犬アイコンを表示する。
 
 ## Important Constraints
-[List any technical, business, or regulatory constraints]
+
+### Non-Goals (MVP)
+- Split View
+- Arc Peek
+- Chrome 実タブの完全同期/置換
+- Today Tabs の自動アーカイブ
+- 実タブから論理タブを推測して自動生成
 
 ## External Dependencies
-[Document key external services, APIs, or systems]
+- Chrome Extension APIs (tabs, storage, sidePanel)

--- a/openspec/specs/design-decisions/spec.md
+++ b/openspec/specs/design-decisions/spec.md
@@ -1,0 +1,137 @@
+# design-decisions Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: 管理対象の定義
+システムが管理・表示するのは「論理タブ（Saved Items / Today Tabs）」のみとする（SHALL）。Chrome の実タブバーを置き換えてはならない（SHALL NOT）。実タブを自動分類・自動同期してはならない（SHALL NOT）。
+
+#### Scenario: 論理タブのみ管理
+- **GIVEN** ユーザーが Chrome で複数のタブを開いている
+- **WHEN** Side Panel を開く
+- **THEN** 拡張が管理する論理タブ（Saved Items / Today Tabs）のみが表示される
+- **AND** Chrome の実タブ一覧は表示されない
+
+#### Scenario: 実タブの自動分類禁止
+- **GIVEN** ユーザーが Chrome 本体で新しいタブを開く
+- **WHEN** 任意の URL に移動する
+- **THEN** その実タブは自動的に Folder に分類されない
+- **AND** 論理タブとして自動生成されない
+
+### Requirement: Today Tabs への自動追加ルール
+Today Tabs に自動追加するのは「拡張 UI 経由で開いた URL」のみとする（SHALL）。以下の操作から開いた URL は Today Tabs に追加されるものとする：
+- New Tab ボタン
+- Pins のクリック
+- Folder 内 Saved Item のクリック
+- 検索結果のクリック
+
+#### Scenario: 拡張 UI 経由での Today Tabs 追加
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** Pins / Saved Item / 検索結果のいずれかをクリックする
+- **THEN** その URL が Today Tabs の先頭に追加される
+
+#### Scenario: 重複 URL の処理
+- **GIVEN** Today Tabs に URL A が既に存在する
+- **WHEN** 同じ URL A を拡張 UI から開く
+- **THEN** 新しい Item は作成されない
+- **AND** 既存の Item が先頭に移動する
+
+### Requirement: Today Tabs への自動追加の対象外
+以下の操作で開いたタブは Today Tabs に自動追加してはならない（SHALL NOT）：
+- Chrome 本体の「＋」ボタン（新規タブ）
+- Chrome のアドレスバーへの URL 入力
+- 外部アプリケーション（メール、Slack 等）からのリンク
+- ブックマークからの直接オープン
+
+#### Scenario: Chrome 本体からの操作は対象外
+- **GIVEN** ユーザーが Chrome 本体で新規タブを開く
+- **WHEN** アドレスバーに URL を入力して移動する
+- **THEN** Today Tabs には追加されない
+
+#### Scenario: 外部アプリからのリンクは対象外
+- **GIVEN** ユーザーがメールアプリでリンクをクリックする
+- **WHEN** Chrome でそのリンクが開かれる
+- **THEN** Today Tabs には追加されない
+
+### Requirement: Today Tabs の自動削除禁止
+システムは Today Tabs を自動的に削除・アーカイブしてはならない（SHALL NOT）。Today Tabs の削除はユーザーの明示的な操作によってのみ行われるものとする（SHALL）。
+
+#### Scenario: 時間経過による自動削除の禁止
+- **GIVEN** Today Tabs に Item が1週間前から存在する
+- **WHEN** 時間が経過する
+- **THEN** その Item は自動で削除されない
+
+#### Scenario: ユーザー操作による削除のみ許可
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** ユーザーが×ボタンをクリックする
+- **THEN** その Item が削除される
+
+### Requirement: Saved Item のクリック挙動（迷子リセット）
+Folder 内の Saved Item は「起点 URL」として固定されるものとする（SHALL）。Saved Item をクリックすると、常にその起点 URL を新規タブで開くものとする（SHALL）。実タブ内でどれだけページ遷移していても、再クリックで起点に戻れることを保証する。
+
+#### Scenario: 起点 URL への復帰
+- **GIVEN** Saved Item（起点URL: https://docs.example.com）が存在する
+- **AND** ユーザーがそのタブ内で https://docs.example.com/page1/page2 まで遷移している
+- **WHEN** ユーザーが Side Panel で同じ Saved Item をクリックする
+- **THEN** https://docs.example.com が新規タブで開かれる
+
+#### Scenario: 常に新規タブで開く
+- **GIVEN** Saved Item が存在する
+- **WHEN** ユーザーが Saved Item をクリックする
+- **THEN** 既存タブを再利用せず、新規タブで起点 URL が開かれる
+
+### Requirement: favicon フォールバック
+favicon が取得できない場合は、デフォルトの犬アイコン（SVG）を表示するものとする（SHALL）。これは全ての Item 表示箇所（Pins / Today Tabs / Folder Tree / 検索結果）に適用される。
+
+#### Scenario: favicon 取得成功
+- **GIVEN** Item の URL から favicon が取得可能
+- **WHEN** Item が表示される
+- **THEN** 取得した favicon が表示される
+
+#### Scenario: favicon 取得失敗時のフォールバック
+- **GIVEN** Item の URL から favicon が取得できない
+- **WHEN** Item が表示される
+- **THEN** デフォルトの犬アイコンが表示される
+
+### Requirement: URL を開く操作は常に新規タブ
+拡張 UI から URL を開く全ての操作において、常に新規タブで開くものとする（SHALL）。既存タブの URL 置き換えや再利用は行わないものとする（SHALL NOT）。
+
+#### Scenario: 全ての URL オープンは新規タブ
+- **GIVEN** ユーザーが Side Panel で任意の Item をクリックする
+- **WHEN** URL が開かれる
+- **THEN** Chrome の新規タブとして開かれる
+- **AND** 既存のタブは変更されない
+
+### Requirement: Non-Goals（MVP で実装しない機能）
+以下の機能は MVP では実装しないものとする（SHALL NOT）。これらに関連する仕様・UI・ロジックを含めてはならない。
+
+- **Split View**: 画面分割表示
+- **Arc Peek**: プレビューポップアップ
+- **Chrome 実タブの完全同期/置換**: 実タブバーの代替
+- **Today Tabs の自動アーカイブ**: 時間経過による自動整理
+- **実タブから論理タブの自動生成**: 実タブを解析して Item を作成
+
+#### Scenario: Non-Goals の機能は存在しない
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** UI を確認する
+- **THEN** Split View / Peek / 自動アーカイブ設定などの UI は存在しない
+
+### Requirement: データの永続化先
+全てのデータは chrome.storage.local に保存するものとする（SHALL）。ストレージキーは "arcish_state" を使用するものとする（SHALL）。外部サーバーへの同期は行わないものとする（SHALL NOT）。
+
+#### Scenario: ローカルストレージのみ使用
+- **GIVEN** ユーザーがデータを変更する
+- **WHEN** データが保存される
+- **THEN** chrome.storage.local にのみ保存される
+- **AND** 外部サーバーには送信されない
+
+### Requirement: capability specs の優先順位
+この design-decisions spec は他の全ての capability specs に優先するものとする（SHALL）。各 capability spec がこの design-decisions と矛盾する場合、design-decisions の内容が優先される。
+
+#### Scenario: 矛盾時の優先順位
+- **GIVEN** capability spec に design-decisions と異なる記述がある
+- **WHEN** 実装判断を行う
+- **THEN** design-decisions の内容を優先する
+
+---
+

--- a/openspec/specs/folder-management/spec.md
+++ b/openspec/specs/folder-management/spec.md
@@ -1,0 +1,70 @@
+# folder-management Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: Folder の定義
+Folder は Space 内の階層構造（ディレクトリ）を表す。各 Folder は親 Folder を持つことができ、木構造を形成するものとする（SHALL）。Folder には Item（Saved Items）を含めることができる。
+
+#### Scenario: Folder の識別
+- **GIVEN** システムに Folder が存在する
+- **WHEN** Folder を参照する
+- **THEN** 一意の ID で識別できる
+
+#### Scenario: Folder のプロパティ
+- **GIVEN** Folder が存在する
+- **WHEN** Folder の情報を取得する
+- **THEN** 名前（name）、所属 Space ID、親 Folder ID（ルートの場合は null）を含む
+
+### Requirement: Folder の作成
+ユーザーは Space 内に新しい Folder を作成できるものとする（SHALL）。
+
+#### Scenario: ルートレベル Folder 作成
+- **GIVEN** アクティブな Space が選択されている
+- **WHEN** ユーザーが新しい Folder を作成する
+- **THEN** 親 Folder を持たないルート Folder が作成される
+
+#### Scenario: サブ Folder 作成
+- **GIVEN** 親 Folder が存在する
+- **WHEN** ユーザーがその Folder 内に新しい Folder を作成する
+- **THEN** 親 Folder の子として新しい Folder が作成される
+
+### Requirement: Folder の展開・折りたたみ
+ユーザーは Folder Tree 内の Folder を展開・折りたたみできるものとする（SHALL）。展開状態は UI 状態として永続化される。
+
+#### Scenario: Folder 展開
+- **GIVEN** 折りたたまれた Folder が存在する
+- **WHEN** ユーザーが Folder をクリックして展開する
+- **THEN** 子 Folder と Item が表示される
+- **AND** expandedFolderIds に追加される
+
+#### Scenario: Folder 折りたたみ
+- **GIVEN** 展開された Folder が存在する
+- **WHEN** ユーザーが Folder をクリックして折りたたむ
+- **THEN** 子 Folder と Item が非表示になる
+- **AND** expandedFolderIds から削除される
+
+### Requirement: Folder の削除
+ユーザーは Folder を削除できるものとする（SHALL）。削除時は、その Folder 内の全ての子 Folder と Item も同時に削除される。
+
+#### Scenario: Folder 削除
+- **GIVEN** Folder が存在する
+- **WHEN** ユーザーが Folder を削除する
+- **THEN** その Folder と全ての子孫（Folder/Item）が削除される
+
+### Requirement: Folder の名前変更
+ユーザーは Folder の名前を変更できるものとする（SHALL）。
+
+#### Scenario: Folder 名前変更
+- **GIVEN** Folder が存在する
+- **WHEN** ユーザーが新しい名前を入力して確定する
+- **THEN** Folder の名前が更新される
+
+### Requirement: Folder Tree の構築
+システムは現在の Space 内の Folder を木構造（Folder Tree）として組み立てて表示するものとする（SHALL）。
+
+#### Scenario: Folder Tree 表示
+- **GIVEN** アクティブな Space が選択されている
+- **WHEN** Side Panel が表示される
+- **THEN** その Space に属する Folder が階層構造で表示される
+

--- a/openspec/specs/item-management/spec.md
+++ b/openspec/specs/item-management/spec.md
@@ -1,0 +1,125 @@
+# item-management Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: Item の定義
+Item（Saved Item / 論理タブ）は保存された URL（起点 URL）を表す。Item は Folder に属するか、または Today Tabs として未整理状態で存在するものとする（SHALL）。システムは Chrome の実タブを置き換えず、論理タブのみを管理する（SHALL）。
+
+#### Scenario: Item の識別
+- **GIVEN** システムに Item が存在する
+- **WHEN** Item を参照する
+- **THEN** 一意の ID で識別できる
+
+#### Scenario: Item のプロパティ
+- **GIVEN** Item が存在する
+- **WHEN** Item の情報を取得する
+- **THEN** URL（起点URL）、タイトル、favicon URL、bucket（"today" | "saved"）、所属 Folder ID（saved の場合）を含む
+
+### Requirement: bucket と folderId の関係
+bucket="saved" の Item は必ず folderId を持つものとする（SHALL）。bucket="today" の Item は folderId を持たない（null）ものとする（SHALL）。
+
+#### Scenario: Saved Item の folderId
+- **GIVEN** bucket="saved" の Item が存在する
+- **WHEN** Item のプロパティを確認する
+- **THEN** folderId は null ではなく、有効な Folder ID を持つ
+
+#### Scenario: Today Tab の folderId
+- **GIVEN** bucket="today" の Item が存在する
+- **WHEN** Item のプロパティを確認する
+- **THEN** folderId は null である
+
+### Requirement: Item の作成（Folder に保存）
+ユーザーは URL を Folder 内に Item として保存できるものとする（SHALL）。
+
+#### Scenario: Item 保存
+- **GIVEN** Folder が存在する
+- **WHEN** ユーザーが URL を Folder に保存する
+- **THEN** bucket="saved" の Item が作成され、指定 Folder に追加される
+
+### Requirement: Item の削除
+ユーザーは Item を削除できるものとする（SHALL）。Item を削除した場合、その Item に関連する全ての参照（Pins、Today Tabs 表示）も同時に削除されるものとする（SHALL）。
+
+#### Scenario: Saved Item 削除
+- **GIVEN** Folder 内に Item が存在する
+- **WHEN** ユーザーが Item を削除する
+- **THEN** Item がストレージから削除される
+
+#### Scenario: Item 削除時の Pin 参照削除
+- **GIVEN** Item が Pins に追加されている
+- **WHEN** その Item を削除する
+- **THEN** Item がストレージから削除される
+- **AND** Pins リストからその Item ID が削除される
+
+#### Scenario: Item 削除時の整合性
+- **GIVEN** Item が存在する
+- **WHEN** その Item を削除する
+- **THEN** 全ての関連参照（pins.bySpaceId 内の itemId）が削除される
+- **AND** 孤立した参照は残らない
+
+### Requirement: Item の移動
+ユーザーは Item を別の Folder に移動できるものとする（SHALL）。MVP では Item の移動はコンテキストメニュー等のメニュー操作で行うものとする（SHALL）。ドラッグ＆ドロップによる移動は MVP のスコープ外とする。
+
+#### Scenario: Item 移動（メニュー操作）
+- **GIVEN** Item が Folder A に存在する
+- **WHEN** ユーザーがメニューから「移動」を選択し、Folder B を指定する
+- **THEN** Item の所属 Folder が B に更新される
+
+> **NOTE (MVP Scope)**: ドラッグ＆ドロップによる Item 移動は MVP では実装しない。メニュー操作（右クリック / ケバブメニュー等）による移動のみをサポートする。
+
+### Requirement: Item の名前（タイトル）変更
+ユーザーは Item のタイトルを変更できるものとする（SHALL）。
+
+#### Scenario: Item 名前変更
+- **GIVEN** Item が存在する
+- **WHEN** ユーザーが新しいタイトルを入力して確定する
+- **THEN** Item のタイトルが更新される
+
+### Requirement: Today Tab から Saved Item への変換
+ユーザーは Today Tab の Item を Folder に保存して Saved Item に変換できるものとする（SHALL）。MVP ではメニュー操作で行うものとする（SHALL）。
+
+#### Scenario: Today Tab を Folder に保存（メニュー操作）
+- **GIVEN** Today Tab の Item が存在する
+- **WHEN** ユーザーがメニューから「Folder に保存」を選択し、保存先 Folder を指定する
+- **THEN** Item の bucket が "saved" に変更され、指定 Folder に所属する
+- **AND** folderId が指定 Folder の ID に設定される
+
+> **NOTE (MVP Scope)**: ドラッグ＆ドロップによる Today Tab → Folder 保存は MVP では実装しない。
+
+### Requirement: Saved Item のクリック挙動（迷子リセット）
+Saved Item（Folder 内の Item）をクリックすると、常に起点 URL を新規タブで開くものとする（SHALL）。実タブ内でどれだけ遷移していても、再クリックで起点に戻れる。
+
+#### Scenario: Saved Item クリック
+- **GIVEN** Folder 内に Item（起点URL: https://example.com）が存在する
+- **WHEN** ユーザーが Item をクリックする
+- **THEN** 常に https://example.com が新規タブで開かれる
+
+### Requirement: favicon の表示
+Item の favicon を表示する。favicon が取得できない場合は、デフォルトの犬アイコンを表示するものとする（SHALL）。
+
+#### Scenario: favicon 表示
+- **GIVEN** Item の favicon URL が有効である
+- **WHEN** Item が表示される
+- **THEN** favicon が表示される
+
+#### Scenario: favicon 取得失敗時
+- **GIVEN** Item の favicon URL が無効または取得不可
+- **WHEN** Item が表示される
+- **THEN** デフォルトの犬アイコンが表示される
+
+### Requirement: Today Tabs における URL の一意性
+Today Tabs では同一 URL（文字列完全一致）の Item は1つのみ存在できるものとする（SHALL）。重複する URL を Today Tabs に追加しようとした場合、新規 Item を作成せず、既存 Item を再利用するものとする（SHALL）。
+
+#### Scenario: Today Tabs への重複 URL 追加
+- **GIVEN** Today Tabs に URL "https://example.com" の Item が存在する
+- **WHEN** 同じ URL "https://example.com" を拡張 UI から開く
+- **THEN** 新しい Item は作成されない
+- **AND** 既存の Item が Today Tabs の先頭に移動する
+
+#### Scenario: URL の完全一致判定
+- **GIVEN** Today Tabs に URL "https://example.com/page" の Item が存在する
+- **WHEN** URL "https://example.com/page?param=1" を開く
+- **THEN** 文字列が完全一致しないため、新しい Item が作成される
+
+> **NOTE**: URL の一意性判定は文字列完全一致で行う。正規化（末尾スラッシュ、クエリパラメータ順序等）は行わない。これは design-decisions の「重複 URL の処理」要件に準拠している。
+

--- a/openspec/specs/pins/spec.md
+++ b/openspec/specs/pins/spec.md
@@ -1,0 +1,57 @@
+# pins Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: Pins の定義
+Pins は Space ごとのお気に入り Item をアイコン列として表示する機能である。各 Space は独立した Pins リストを持つものとする（SHALL）。
+
+#### Scenario: Pins の構造
+- **GIVEN** Space が存在する
+- **WHEN** Pins を参照する
+- **THEN** その Space に紐づく Item ID の配列（順序付き）が取得できる
+
+### Requirement: Pins の表示
+Pins は Side Panel の上部に横並びのアイコン列として表示されるものとする（SHALL）。
+
+#### Scenario: Pins 表示
+- **GIVEN** アクティブな Space に Pins が設定されている
+- **WHEN** Side Panel が表示される
+- **THEN** Pins がアイコン列として表示される（favicon または犬アイコン）
+
+### Requirement: Item を Pins に追加
+ユーザーは Item を現在の Space の Pins に追加できるものとする（SHALL）。
+
+#### Scenario: Pins 追加
+- **GIVEN** Item が存在する
+- **WHEN** ユーザーが Item を Pins に追加する
+- **THEN** その Item が Pins リストの末尾に追加される
+
+### Requirement: Pins から Item を削除
+ユーザーは Pins から Item を削除できるものとする（SHALL）。Item 自体は削除されない。
+
+#### Scenario: Pins 削除
+- **GIVEN** Item が Pins に追加されている
+- **WHEN** ユーザーが Pins から削除する
+- **THEN** Pins リストからその Item が削除される
+- **AND** Item 自体は引き続き存在する
+
+### Requirement: Pins のクリック挙動
+Pins をクリックすると、その Item の起点 URL を新規タブで開き、Today Tabs の先頭に追加するものとする（SHALL）。
+
+#### Scenario: Pins クリック
+- **GIVEN** Pins に Item が存在する
+- **WHEN** ユーザーが Pin アイコンをクリックする
+- **THEN** その Item の URL が新規タブで開かれる
+- **AND** Today Tabs の先頭に追加される
+
+### Requirement: Pins の表示順序
+Pins は追加された順序で表示されるものとする（SHALL）。新しく追加された Pin は末尾に配置される。
+
+#### Scenario: Pins の追加順序
+- **GIVEN** Pins に Item A, B が順に追加されている
+- **WHEN** Item C を Pins に追加する
+- **THEN** Pins は A, B, C の順序で表示される
+
+> **NOTE (MVP Scope)**: Pins の並び替え（ドラッグ＆ドロップによる順序変更）は MVP では実装しない。将来的に順序変更が必要になった場合に検討する。
+

--- a/openspec/specs/search/spec.md
+++ b/openspec/specs/search/spec.md
@@ -1,0 +1,51 @@
+# search Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: 検索入力の常時表示
+Side Panel の上部に検索入力フィールドを常時表示するものとする（SHALL）。
+
+#### Scenario: 検索入力表示
+- **GIVEN** Side Panel が開いている
+- **WHEN** ユーザーが Side Panel を見る
+- **THEN** 検索入力フィールドが常に表示されている
+
+### Requirement: 検索対象
+検索は現在の Space 内の全 Item（Today Tabs + Saved Items）を対象とするものとする（SHALL）。検索対象は Item のタイトルと URL。
+
+#### Scenario: 検索対象範囲
+- **GIVEN** アクティブな Space に Item が存在する
+- **WHEN** ユーザーが検索クエリを入力する
+- **THEN** Today Tabs と Folder 内の全 Item が検索対象となる
+
+### Requirement: 検索フィルタリング
+ユーザーが検索クエリを入力すると、マッチする Item のみが表示されるものとする（SHALL）。
+
+#### Scenario: 検索実行
+- **GIVEN** 複数の Item が存在する
+- **WHEN** ユーザーが "example" と入力する
+- **THEN** タイトルまたは URL に "example" を含む Item のみ表示される
+
+#### Scenario: 検索クリア
+- **GIVEN** 検索フィルタが適用されている
+- **WHEN** ユーザーが検索入力をクリアする
+- **THEN** 全ての Item が通常通り表示される
+
+### Requirement: 検索結果のクリック挙動
+検索結果の Item をクリックすると、その URL を新規タブで開き、Today Tabs の先頭に追加するものとする（SHALL）。
+
+#### Scenario: 検索結果クリック
+- **GIVEN** 検索結果に Item が表示されている
+- **WHEN** ユーザーが Item をクリックする
+- **THEN** その Item の URL が新規タブで開かれる
+- **AND** Today Tabs の先頭に追加される
+
+### Requirement: インクリメンタル検索
+検索は入力に応じてリアルタイムでフィルタリングを行うものとする（SHALL）。
+
+#### Scenario: インクリメンタル検索
+- **GIVEN** 検索入力フィールドにフォーカスがある
+- **WHEN** ユーザーが文字を入力する
+- **THEN** 入力ごとにフィルタ結果が即座に更新される
+

--- a/openspec/specs/side-panel-ui/spec.md
+++ b/openspec/specs/side-panel-ui/spec.md
@@ -1,0 +1,83 @@
+# side-panel-ui Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: Side Panel の使用
+UI は Chrome の Side Panel 上に React アプリとして構築するものとする（SHALL）。
+
+#### Scenario: Side Panel 表示
+- **GIVEN** 拡張がインストールされている
+- **WHEN** ユーザーが拡張アイコンをクリックする
+- **THEN** Side Panel が開き、React UI が表示される
+
+### Requirement: UI セクション構成
+Side Panel は上から順に以下のセクションを表示するものとする（SHALL）：
+1. Header：Space Switcher / Settings
+2. Search：常時表示の検索入力
+3. Pins：横並びアイコン列（favicon or 犬アイコン）
+4. New Tab：拡張経由の新規タブ作成ボタン
+5. Today Tabs：未整理リスト（削除は×ボタン）
+6. Folder Tree：フォルダ階層＋保存 Item
+
+#### Scenario: セクション順序
+- **GIVEN** Side Panel が開いている
+- **WHEN** UI を確認する
+- **THEN** Header → Search → Pins → New Tab → Today Tabs → Folder Tree の順で表示される
+
+### Requirement: Header セクション
+Header には Space Switcher（ドロップダウンまたはタブ）と Settings アクセスを配置するものとする（SHALL）。
+
+#### Scenario: Header 表示
+- **GIVEN** Side Panel が開いている
+- **WHEN** Header を確認する
+- **THEN** 現在の Space 名と切り替え UI が表示される
+
+### Requirement: Pins セクション
+Pins は favicon（または犬アイコン）の横並びアイコン列として表示するものとする（SHALL）。
+
+#### Scenario: Pins アイコン表示
+- **GIVEN** 現在の Space に Pins が設定されている
+- **WHEN** Pins セクションを確認する
+- **THEN** アイコンが横一列に並んで表示される
+
+### Requirement: New Tab ボタン
+New Tab ボタンは Pins と Today Tabs の間に配置するものとする（SHALL）。
+
+#### Scenario: New Tab ボタン配置
+- **GIVEN** Side Panel が開いている
+- **WHEN** UI を確認する
+- **THEN** Pins の下、Today Tabs の上に New Tab ボタンが表示される
+
+### Requirement: Today Tabs セクション
+Today Tabs は未整理リストとして表示し、各 Item に削除用の×ボタンを表示するものとする（SHALL）。
+
+#### Scenario: Today Tabs リスト表示
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** Today Tabs セクションを確認する
+- **THEN** Item がリスト形式で表示され、各 Item に×ボタンがある
+
+### Requirement: Folder Tree セクション
+Folder Tree はフォルダ階層と保存 Item を木構造で表示するものとする（SHALL）。展開・折りたたみが可能。
+
+#### Scenario: Folder Tree 表示
+- **GIVEN** Folder と Saved Item が存在する
+- **WHEN** Folder Tree セクションを確認する
+- **THEN** フォルダが階層構造で表示され、クリックで展開・折りたたみできる
+
+### Requirement: 犬アイコンのフォールバック
+favicon が取得できない場合は、デフォルトの犬アイコン（SVG）を表示するものとする（SHALL）。
+
+#### Scenario: 犬アイコン表示
+- **GIVEN** Item の favicon が取得できない
+- **WHEN** Item が表示される
+- **THEN** favicon の代わりに犬アイコンが表示される
+
+### Requirement: React によるUI実装
+UI は React を使用して実装するものとする（SHALL）。
+
+#### Scenario: React アプリ
+- **GIVEN** Side Panel が開かれる
+- **WHEN** HTML がロードされる
+- **THEN** React アプリがマウントされて UI がレンダリングされる
+

--- a/openspec/specs/space-management/spec.md
+++ b/openspec/specs/space-management/spec.md
@@ -1,0 +1,52 @@
+# space-management Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: Space の定義
+Space は作業コンテキスト（Work / Private など）を表す最上位の論理単位である。システムは複数の Space を管理し、各 Space は独立した Folder 構造と Pins を持つものとする（SHALL）。
+
+#### Scenario: Space の識別
+- **GIVEN** システムに Space が存在する
+- **WHEN** Space を参照する
+- **THEN** 一意の ID で識別できる
+
+#### Scenario: Space のプロパティ
+- **GIVEN** Space が存在する
+- **WHEN** Space の情報を取得する
+- **THEN** 名前（name）と作成日時を含む
+
+### Requirement: Space の作成
+ユーザーは新しい Space を作成できるものとする（SHALL）。
+
+#### Scenario: 新規 Space 作成
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** 新しい Space 名を入力して作成を実行する
+- **THEN** 新しい Space が作成され、空の Folder 構造と Pins リストが初期化される
+
+### Requirement: Space の切り替え
+ユーザーは Header の Space Switcher を使用して、アクティブな Space を切り替えられるものとする（SHALL）。
+
+#### Scenario: Space 切り替え
+- **GIVEN** 複数の Space が存在する
+- **WHEN** ユーザーが別の Space を選択する
+- **THEN** UI が選択された Space の内容（Pins / Today Tabs / Folders）を表示する
+- **AND** activeSpaceId が更新される
+
+### Requirement: Space の削除
+ユーザーは Space を削除できるものとする（SHALL）。削除時は、その Space に属する全ての Folder、Item、Pins も同時に削除される。
+
+#### Scenario: Space 削除
+- **GIVEN** 複数の Space が存在する
+- **WHEN** ユーザーが Space を削除する
+- **THEN** その Space と関連する全データが削除される
+- **AND** 別の Space が自動的にアクティブになる
+
+### Requirement: Space の名前変更
+ユーザーは Space の名前を変更できるものとする（SHALL）。
+
+#### Scenario: Space 名前変更
+- **GIVEN** Space が存在する
+- **WHEN** ユーザーが新しい名前を入力して確定する
+- **THEN** Space の名前が更新される
+

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -1,0 +1,100 @@
+# storage Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: chrome.storage.local の使用
+データ永続化には chrome.storage.local を使用するものとする（SHALL）。ストレージキーは "arcish_state"。
+
+#### Scenario: データ保存
+- **GIVEN** ユーザーがデータを変更する
+- **WHEN** 変更が確定される
+- **THEN** chrome.storage.local の "arcish_state" キーにデータが保存される
+
+#### Scenario: データ読み込み
+- **GIVEN** 拡張が起動する
+- **WHEN** Side Panel が初期化される
+- **THEN** chrome.storage.local から "arcish_state" を読み込んで状態を復元する
+
+### Requirement: Storage ラッパー
+chrome.storage.local の薄いラッパーを用意し、set/get の I/F を統一するものとする（SHALL）。
+
+#### Scenario: Storage ラッパー使用
+- **GIVEN** UI コンポーネントがデータを操作する
+- **WHEN** データの読み書きを行う
+- **THEN** 統一された get/set API を通じてアクセスする
+
+### Requirement: Zod によるスキーマバリデーション
+ストレージに保存するデータは Zod でスキーマバリデーションを行うものとする（SHALL）。
+
+#### Scenario: データ保存時のバリデーション
+- **GIVEN** データを保存しようとする
+- **WHEN** データが Zod スキーマに適合しない
+- **THEN** エラーが発生し、不正なデータは保存されない
+
+### Requirement: Normalized データ構造
+データは正規化（Normalized）された構造で保存するものとする（SHALL）。
+
+#### Scenario: Normalized 構造
+- **GIVEN** データを保存する
+- **WHEN** ストレージ構造を確認する
+- **THEN** 以下の構造で保存されている:
+  - version: number（スキーマバージョン）
+  - spaces: { byId: {}, allIds: [] }
+  - folders: { byId: {}, allIds: [] }
+  - items: { byId: {}, allIds: [] }
+  - pins: { bySpaceId: { [spaceId]: itemId[] } }
+  - ui: { activeSpaceId, expandedFolderIds }
+
+### Requirement: スキーマバージョン管理
+ストレージに保存するデータには `version: number` フィールドを含めるものとする（SHALL）。初期値は `1` とする（SHALL）。将来のデータ構造変更時にマイグレーションを可能にするためのフィールドである。
+
+#### Scenario: 初期バージョン
+- **GIVEN** 拡張を初めてインストールする
+- **WHEN** 初期データが作成される
+- **THEN** version フィールドの値は 1 である
+
+#### Scenario: バージョンの永続化
+- **GIVEN** データがストレージに保存されている
+- **WHEN** データを読み込む
+- **THEN** version フィールドが含まれている
+
+> **NOTE**: スキーマ変更が発生した場合、version を参照してマイグレーション処理を行う。MVP では version=1 のみをサポートし、マイグレーションロジックは将来の拡張として実装する。
+
+### Requirement: 更新単位（全体保存）
+MVP ではストレージは state 全体を1つのオブジェクトとして保存・更新するものとする（SHALL）。部分的な差分更新は行わないものとする（SHALL NOT）。
+
+#### Scenario: 全体保存
+- **GIVEN** ユーザーが Item を1つ追加する
+- **WHEN** ストレージを更新する
+- **THEN** state 全体が1つのオブジェクトとして chrome.storage.local に保存される
+
+#### Scenario: 差分更新の禁止
+- **GIVEN** state の一部のみが変更された
+- **WHEN** ストレージを更新する
+- **THEN** 変更された部分だけでなく、state 全体を保存する
+- **AND** 部分的なキー更新（例: spaces のみ更新）は行わない
+
+> **NOTE**: 全体保存はシンプルさを優先した MVP 方針である。パフォーマンス上の問題が発生した場合、将来的に差分更新を検討する。
+
+### Requirement: UI 状態の永続化
+UI 状態（activeSpaceId、expandedFolderIds など）も同じストアに含めて永続化するものとする（SHALL）。
+
+#### Scenario: UI 状態の保存
+- **GIVEN** ユーザーが Folder を展開する
+- **WHEN** Side Panel を閉じて再度開く
+- **THEN** 展開状態が復元される
+
+#### Scenario: アクティブ Space の保存
+- **GIVEN** ユーザーが Space を切り替える
+- **WHEN** ブラウザを再起動する
+- **THEN** 最後にアクティブだった Space が選択される
+
+### Requirement: 初期データ
+ストレージが空の場合、デフォルトの初期データを生成するものとする（SHALL）。
+
+#### Scenario: 初回起動時の初期化
+- **GIVEN** 拡張を初めてインストールする
+- **WHEN** ストレージが空である
+- **THEN** デフォルトの Space（例: "Default"）と空の構造が作成される
+

--- a/openspec/specs/tab-opening/spec.md
+++ b/openspec/specs/tab-opening/spec.md
@@ -1,0 +1,47 @@
+# tab-opening Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: 常に新規タブで開く
+拡張 UI から URL を開く場合、常に新規タブで開くものとする（SHALL）。既存タブの再利用やタブの置き換えは行わない。
+
+#### Scenario: URL を新規タブで開く
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** Item、Pin、検索結果、New Tab ボタンのいずれかをクリックして URL を開く
+- **THEN** Chrome の新規タブで URL が開かれる
+
+### Requirement: New Tab ボタン
+Side Panel に New Tab ボタンを配置し、クリックすると空の新規タブ（chrome://newtab）を開くものとする（SHALL）。
+
+#### Scenario: New Tab ボタンクリック
+- **GIVEN** Side Panel が開いている
+- **WHEN** ユーザーが New Tab ボタンをクリックする
+- **THEN** chrome://newtab が新規タブで開かれる
+
+### Requirement: Tab 作成時の Today Tabs 追加
+拡張 UI 経由で URL を開いた場合、その URL を Today Tabs の先頭に追加するものとする（SHALL）。
+
+#### Scenario: Tab 作成と Today Tabs 追加
+- **GIVEN** Folder 内に Item（URL: https://example.com）が存在する
+- **WHEN** ユーザーが Item をクリックする
+- **THEN** https://example.com が新規タブで開かれる
+- **AND** Today Tabs の先頭に追加される（bucket="today" の Item として）
+
+### Requirement: 重複 URL の処理
+既に Today Tabs に同じ URL が存在する場合、重複作成せず既存 Item を先頭に移動するものとする（SHALL）。
+
+#### Scenario: 重複 URL を開く
+- **GIVEN** Today Tabs に URL A の Item が存在する
+- **WHEN** ユーザーが同じ URL A を別の場所から開く
+- **THEN** 新規タブは開かれる
+- **AND** 既存の Today Tab Item が先頭に移動する（重複作成しない）
+
+### Requirement: Background Service Worker での Tab 作成
+タブ作成は Background Service Worker（tabs.create API）を通じて行うものとする（SHALL）。
+
+#### Scenario: tabs.create 呼び出し
+- **GIVEN** ユーザーが URL を開く操作を行う
+- **WHEN** Side Panel が chrome.tabs.create を呼び出す
+- **THEN** 新規タブが作成される
+

--- a/openspec/specs/today-tabs/spec.md
+++ b/openspec/specs/today-tabs/spec.md
@@ -1,0 +1,66 @@
+# today-tabs Specification
+
+## Purpose
+TBD - created by archiving change add-initial-specs. Update Purpose after archive.
+## Requirements
+### Requirement: Today Tabs の定義
+Today Tabs は未整理の作業中 URL 一覧である。bucket="today" の Item がここに表示されるものとする（SHALL）。Today Tabs は自動で消さず、ユーザーが明示的に削除するまで保持されるものとする（SHALL）。
+
+#### Scenario: Today Tabs の識別
+- **GIVEN** Item が存在する
+- **WHEN** Item の bucket が "today" である
+- **THEN** その Item は Today Tabs に表示される
+
+### Requirement: Today Tabs の表示
+Today Tabs は Side Panel の Folder Tree の上に、未整理リストとして表示されるものとする（SHALL）。各 Item には×ボタン（削除）が表示される。
+
+#### Scenario: Today Tabs 表示
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** Side Panel が表示される
+- **THEN** Today Tabs セクションに Item リストが表示される
+- **AND** 各 Item に×ボタンが表示される
+
+### Requirement: Today Tabs への自動追加（拡張経由）
+拡張 UI（New Tab ボタン、Pins、Folder 内 Item、検索結果）から URL を開いた場合、Today Tabs の先頭に自動追加するものとする（SHALL）。
+
+#### Scenario: 拡張 UI から URL を開く
+- **GIVEN** ユーザーが Side Panel を開いている
+- **WHEN** New Tab ボタン、Pin、Folder Item、検索結果のいずれかをクリックして URL を開く
+- **THEN** その URL が Today Tabs の先頭に追加される（重複時は既存を先頭に移動）
+
+### Requirement: Today Tabs への自動追加の対象外
+Chrome 本体の「＋」新規タブ、アドレスバー入力、外部アプリ起点で開いたタブは Today Tabs に自動追加しないものとする（SHALL NOT）。
+
+#### Scenario: Chrome 本体からタブを開く
+- **GIVEN** ユーザーが Chrome 本体で新規タブを開く
+- **WHEN** アドレスバーに URL を入力して移動する
+- **THEN** Today Tabs には追加されない
+
+### Requirement: Today Tabs の手動削除
+ユーザーは Today Tab の×ボタンをクリックして、その Item を削除できるものとする（SHALL）。
+
+#### Scenario: Today Tab 削除
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** ユーザーが×ボタンをクリックする
+- **THEN** その Item がストレージから削除される
+
+### Requirement: Today Tabs は自動削除しない
+システムは Today Tabs を自動的に削除・アーカイブしないものとする（SHALL NOT）。
+
+#### Scenario: Today Tabs の自動削除禁止
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** 時間が経過する（1日後、1週間後など）
+- **THEN** Item は自動で削除されない
+
+### Requirement: Today Tab から Folder への保存
+ユーザーは Today Tab の Item を Folder に保存して Saved Item に変換できるものとする（SHALL）。MVP では、メニュー操作（コンテキストメニュー / ケバブメニュー等）による明示的な UI 操作で行うものとする（SHALL）。
+
+#### Scenario: Today Tab を Folder に保存（メニュー操作）
+- **GIVEN** Today Tabs に Item が存在する
+- **WHEN** ユーザーがメニューから「Folder に保存」を選択し、保存先 Folder を指定する
+- **THEN** Item の bucket が "saved" に変更される
+- **AND** folderId が指定 Folder の ID に設定される
+- **AND** Today Tabs から消える（bucket が "today" でなくなるため）
+
+> **NOTE (MVP Scope)**: ドラッグ＆ドロップによる Today Tab → Folder 保存は MVP では実装しない。メニュー操作のみをサポートする。これは item-management spec の方針と整合している。
+


### PR DESCRIPTION
…sion

- Add 10 capability specs:
  - design-decisions: Cross-cutting design decisions (read first)
  - space-management: Space CRUD and switching
  - folder-management: Folder hierarchy management
  - item-management: Saved Items (logical tabs) management
  - pins: Favorites icon row per Space
  - today-tabs: Unsorted working URLs list
  - search: Global search functionality
  - tab-opening: Open URLs in new tabs
  - storage: chrome.storage.local persistence
  - side-panel-ui: Side Panel UI structure

- Total: 71 requirements with scenarios
- Archive initial spec proposal

Key design decisions:
- Manage logical tabs only (not Chrome actual tabs)
- Today Tabs auto-add only via extension UI
- Today Tabs never auto-delete
- Saved Item click always opens origin URL in new tab
- Dog icon fallback for missing favicons
- MVP excludes: Split View, Peek, D&D operations